### PR TITLE
feat: 아카라이브 캡챠 해결을 위한 프록시 서버 구성

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       - "com.centurylinklabs.watchtower.enable=true"
     environment:
       - CLEANERBOT_TOKEN=${CLEANERBOT_TOKEN1}
+    ports:
+      - "8087:8087"
   clb2:
     restart: always
     image: a891/cleanerbot:latest

--- a/production/docker-compose.yml
+++ b/production/docker-compose.yml
@@ -4,3 +4,5 @@ services:
         build: ..
         environment:
             - CLEANERBOT_TOKEN=${CLEANERBOT_TOKEN}
+        ports:
+            - "8087:8087"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ discord.py == 1.7.3
 
 # C:\Users\DPS0340\Programming\cleanerbot\src\cleaner.py: 9
 pyquery == 1.4.3
+
+brotlipy == 0.7.0

--- a/src/cleaner.py
+++ b/src/cleaner.py
@@ -11,6 +11,7 @@ from pyquery import PyQuery as pq
 import json
 from log import logger
 from discord.ext import commands
+from constants import ip_address, webserver_port
 import random
 
 sessions = dict()
@@ -240,7 +241,9 @@ async def cleanArcaLive(bot: discord.Client, ctx: commands.Context, id: str, pw:
                 link = link.replace('?showComments=all', '')
                 if "#c_" in link:
                     link = link.replace("#c_", "/")
-                link = 'https://arca.live%s/delete' % link
+                original_link = link
+                link = f'https://arca.live{link}/delete'
+                proxy_link = f'http://{ip_address}:{webserver_port}{original_link}/delete'
                 delete_page = await s.get(link)
 
                 text = await delete_page.content.read()
@@ -252,7 +255,7 @@ async def cleanArcaLive(bot: discord.Client, ctx: commands.Context, id: str, pw:
                 if res.status == 429:
                     logger.info(f"Captcha generated")
                     ask: discord.Message = await channel.send(f"""캡챠 발생!
-{link} 주소로 가서 삭제를 클릭 후 캡챠를 풀어주세요.
+{proxy_link} 주소로 가셔서 로그인 후 삭제를 클릭 후 캡챠를 풀어주세요.
 캡챠를 푸신 다음, 이모지를 클릭 해주세요.""")
                     await ask.add_reaction('🆗')
                     def check(payload: discord.RawReactionActionEvent):

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,0 +1,9 @@
+def get_ip_address():
+    import socket
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+        sock.connect(("8.8.8.8", 80))
+        ip_addr = sock.getsockname()[0]
+    return ip_addr
+
+ip_address = get_ip_address()
+webserver_port = 8087

--- a/src/main.py
+++ b/src/main.py
@@ -1,10 +1,13 @@
 import asyncio
+import logging
 from discord.ext import commands
 from discord import Embed
 import discord
+from server import Webserver
 import cleaner
 from cleanerbot_token import get_token
 from log import logger
+from constants import ip_address
 
 
 prefix = "clb "
@@ -13,9 +16,9 @@ token = get_token()
 
 auths = dict()
 
-
 @bot.event
 async def on_ready():
+    logging.info(f"bot ip address: {ip_address}")
     print('Logged on as {0}!'.format(bot.user))
 
 
@@ -144,4 +147,6 @@ def isDM(message):
     return not message.guild
 
 
-bot.run(token)
+if __name__ == '__main__':
+    bot.add_cog(Webserver(bot))
+    bot.run(token)

--- a/src/server.py
+++ b/src/server.py
@@ -1,0 +1,59 @@
+from aiohttp import web
+from constants import webserver_port
+from discord.ext import commands, tasks
+import aiohttp
+from log import logger
+from cleaner import header
+
+app = web.Application()
+routes = web.RouteTableDef()
+class Webserver(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.webserver_port = webserver_port
+        self.sessions = {}
+        app.router.add_routes([
+            web.get('', self.arca_proxy),
+            web.post('', self.arca_proxy),
+            web.get('/{url:.*}', self.arca_proxy),
+            web.post('/{url:.*}', self.arca_proxy)])
+        self.web_server.start()
+
+    async def arca_proxy(self, request: web.Request):
+        url = request.path_qs
+        headers = request.headers.copy()
+
+        logger.info(f'Headers: {headers}')
+        logger.info(f'URL: {url}')
+        if url.startswith('favicon.ico'):
+            url = f"/static{url}"
+        remote_url = f"https://arca.live{url}"
+
+        request_header = {**header, 'Referer': remote_url}
+        
+        if self.sessions.get(request.remote):
+            session = self.sessions[request.remote]
+        else:
+            session = aiohttp.ClientSession(headers=request_header)
+            self.sessions[request.remote] = session 
+
+        http_method = session.post if request.method == 'POST' else session.get
+        if request.method == 'POST':
+            data = await request.post()
+            req = await http_method(remote_url, data=data, ssl=False)
+        else:
+            req = await http_method(remote_url, ssl=False)
+        body = await req.read()
+        text = body.decode('utf-8')
+        return web.Response(text=text, status=req.status, content_type=req.content_type)
+
+    @tasks.loop()
+    async def web_server(self):
+        runner = web.AppRunner(app)
+        await runner.setup()
+        site = web.TCPSite(runner, host='0.0.0.0', port=self.webserver_port)
+        await site.start()
+
+    @web_server.before_loop
+    async def web_server_before_loop(self):
+        await self.bot.wait_until_ready()


### PR DESCRIPTION
8087 포트로 프록시 서버를 정하고, aiohttp를 웹서버 프레임워크로 사용하여 구현함.
discord.py의 cog로 연동하였음.
아카라이브 관련 모든 리퀘스트를 8087 포트로 접속하면 포워딩해줌.
관련 캡챠 메시지도 수정. public IP를 출력해서 로그인시키도록 변경하였음.